### PR TITLE
chore: remove unused workbench settings from VS Code configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,9 +16,5 @@
         ".pytest_cache": true,
         ".dtproject": true
     },
-    "workbench.tree.indent": 24,
-    "notebook.dragAndDropEnabled": false,
-    "workbench.colorTheme": "Default Light+",
-    "workbench.iconTheme": "vs-minimal",
-    "editor.suggest.showIcons": true
+    "workbench.tree.indent": 24
 }


### PR DESCRIPTION
This pull request makes a minor update to the `.vscode/settings.json` file, removing several editor and theme-related settings to streamline the workspace configuration. Only the `workbench.tree.indent` setting is retained.