### PR TITLE
Update instructions for launching ROS container

### DIFF
--- a/notebooks/04_ros_nodes.ipynb
+++ b/notebooks/04_ros_nodes.ipynb
@@ -30,8 +30,6 @@
     "\n",
     "    dts code vnc -R [!ROBOT_NAME]\n",
     "\n",
-    "**NOTE** that you will want to add the `-m` flag if you using a virtual duckiebot as described in the [README](../README.md).\n",
-    "\n",
     "This will spin up a container with ROS installed. \n",
     "A link will appear in the terminal that, when clicked, will open a lightweight VNC desktop environment:\n",
     "\n",


### PR DESCRIPTION
Removed note about the `-m` flag for virtual duckiebots for dts code vnc